### PR TITLE
merge from konsum-frontend-svelte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules
 .tmp
 *.node
 .test
+bundle.*
 *.map

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   ],
   "license": "BSD-2-Clause",
   "scripts": {
-    "prepare": "vite build",
+    "prepare": "vite build && rollup -c",
     "startkonsum": "node_modules/konsum/src/konsum-cli.mjs -c tests/config start",
     "startfrontend": "npm run dev",
-    "start": "vite",
+    "start": "vite && rollup -c -w",
     "test": "npm run test:ava && npm run test:cafe",
-    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --app-init-delay 7000 --app \"vite\"",
+    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --app-init-delay 7000 --app \"rollup -c  -w\"",
     "test:ava": "ava --timeout 2m tests/*.mjs",
     "cafeHead": "testcafe chrome tests/cafe/deleteValues.js -s build/test",
     "dev": "vite",
@@ -47,13 +47,35 @@
   },
   "devDependencies": {
     "@konsumation/konsum": "github:konsumation/konsum",
+    "@rollup/plugin-alias": "^3.1.9",
+    "@rollup/plugin-babel": "^5.3.0",
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-inject": "^4.0.3",
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-replace": "^3.0.0",
+    "@rollup/plugin-typescript": "^8.3.0",
+    "@rollup/plugin-virtual": "^2.0.3",
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.36",
     "ava": "^4.0.1",
     "konsum": "github:konsumation/konsum",
-    "npm-pkgbuild": "^7.25.3",
+    "npm-pkgbuild": "^7.25.5",
+    "postcss": "^8.4.6",
+    "postcss-import": "^14.0.2",
+    "rollup": "^2.67.0",
+    "rollup-plugin-cleanup": "^3.2.1",
+    "rollup-plugin-consts": "^1.0.2",
+    "rollup-plugin-dev": "^1.1.3",
+    "rollup-plugin-executable": "^1.6.3",
+    "rollup-plugin-gzip": "2.5.0",
+    "rollup-plugin-livereload": "^2.0.5",
+    "rollup-plugin-native": "^1.2.16",
+    "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-svelte": "^7.1.0",
+    "rollup-plugin-terser": "^7.0.2",
     "semantic-release": "^19.0.2",
     "svelte": "^3.46.4",
     "testcafe": "^1.18.3",
@@ -70,26 +92,27 @@
   "config": {
     "api": "/services/konsum/api",
     "base": "/services/konsum",
+    "proxyTarget": "https://somewhere/",
     "title": "Konsum"
   },
   "pkg": {
-    "name": "konsum-frontend-svelte",
     "content": {
       "${installdir}/": {
         "base": "build"
       },
       "/etc/nginx/sites/common/${name}.conf": "pkg/nginx.conf"
     },
+    "output": {
+      "arch": {}
+    },
+    "hooks": "pkg/hooks.sh",
+    "groups": "web",
     "depends": {
       "nginx-mainline": ">=1.21.4",
       "konsum": ">=5.0.39"
     },
-    "groups": "web",
-    "hooks": "pkg/hooks.sh",
     "installdir": "/services/konsum/frontend",
-    "output": {
-      "arch": {}
-    }
+    "name": "konsum-frontend-svelte"
   },
   "release": {
     "plugins": [
@@ -97,6 +120,12 @@
         "@semantic-release/exec",
         {
           "publishCmd": "npx npm-pkgbuild --verbose"
+        }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "publishCmd": "npx npm-pkgbuild"
         }
       ],
       "@semantic-release/commit-analyzer",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,115 @@
+import { readFileSync } from "fs";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import virtual from "@rollup/plugin-virtual";
+
+import svelte from "rollup-plugin-svelte";
+import postcss from "rollup-plugin-postcss";
+import postcssImport from "postcss-import";
+
+import { terser } from "rollup-plugin-terser";
+import dev from "rollup-plugin-dev";
+import livereload from 'rollup-plugin-livereload';
+import consts from "rollup-plugin-consts";
+
+const production = !process.env.ROLLUP_WATCH;
+const dist = "public";
+const bundlePrefix = `${dist}/bundle.`;
+const port = 5000;
+
+const { name, description, version, config } = JSON.parse(
+  readFileSync("./package.json", { endoding: "utf8" })
+);
+
+const external = [];
+
+const prePlugins = [
+  virtual({
+    "node-fetch": "export default fetch",
+    stream: "export class Readable {}"
+  }),
+  consts({
+    name,
+    version,
+    description,
+    ...config
+  })
+];
+
+const resolverPlugins = [
+  resolve({
+    browser: true,
+    preferBuiltins: false,
+    dedupe: importee => importee === "svelte" || importee.startsWith("svelte/")
+  }),
+  commonjs()
+];
+
+const devPlugins = production
+  ? []
+  : [
+      dev({
+        port,
+        dirs: [dist],
+        spa: `${dist}/index.html`,
+        basePath: config.base,
+        proxy: {
+          [`${config.api}/*`]: [
+            config.proxyTarget,
+            {
+              https: config.proxyTarget.startsWith("https:"),
+              proxyReqPathResolver: ctx => ctx.url.substring(config.api.length)
+            }
+          ]
+        }
+      }),
+      livereload({
+        watch: dist,
+        verbose: true
+      })
+    ];
+
+const output = {
+  interop: false,
+  sourcemap: true,
+  format: "esm",
+  file: `${bundlePrefix}main.mjs`,
+  plugins: [production && terser()]
+};
+
+export default [
+  {
+    input: "src/main.mjs",
+    treeshake: production,
+    output,
+    plugins: [
+      ...prePlugins,
+      postcss({
+        extract: true,
+        sourceMap: true,
+        minimize: production,
+        plugins: [postcssImport]
+      }),
+      svelte({
+        compilerOptions: {
+          dev: !production
+        }
+      }),
+      ...resolverPlugins,
+      ...devPlugins
+    ],
+    external,
+    watch: {
+      clearScreen: false
+    }
+  },
+  {
+    input: "src/service-worker/main.mjs",
+    output: {
+      ...output,
+      file: `${bundlePrefix}service-worker.mjs`,
+    },
+    plugins: [...prePlugins, ...resolverPlugins],
+    external
+  }
+];


### PR DESCRIPTION
package.json
---
- chore(scripts): add vite build && rollup -c (scripts.prepare)
chore(scripts): add vite && rollup -c -w (scripts.start)
chore(scripts): add testcafe $BROWSER:headless tests/cafe/*.js -s build/test --app-init-delay 7000 --app "rollup -c  -w" (scripts.test:cafe)
chore(deps): add ^7.25.5 remove ^7.25.3 (devDependencies.npm-pkgbuild)
chore(deps): add ^2.0.5 (devDependencies.rollup-plugin-livereload)
chore(deps): add ^7.1.0 (devDependencies.rollup-plugin-svelte)
chore(deps): add ^4.0.2 (devDependencies.rollup-plugin-postcss)
chore(deps): add ^14.0.2 (devDependencies.postcss-import)
chore(deps): add ^8.4.6 (devDependencies.postcss)
chore(deps): add ^2.67.0 (devDependencies.rollup)
chore(deps): add ^3.1.9 (devDependencies.@rollup/plugin-alias)
chore(deps): add ^13.1.3 (devDependencies.@rollup/plugin-node-resolve)
chore(deps): add ^4.1.0 (devDependencies.@rollup/plugin-json)
chore(deps): add ^21.0.1 (devDependencies.@rollup/plugin-commonjs)
chore(deps): add ^8.3.0 (devDependencies.@rollup/plugin-typescript)
chore(deps): add ^5.3.0 (devDependencies.@rollup/plugin-babel)
chore(deps): add ^2.0.3 (devDependencies.@rollup/plugin-virtual)
chore(deps): add ^4.0.3 (devDependencies.@rollup/plugin-inject)
chore(deps): add ^3.0.0 (devDependencies.@rollup/plugin-replace)
chore(deps): add ^1.6.3 (devDependencies.rollup-plugin-executable)
chore(deps): add ^1.2.16 (devDependencies.rollup-plugin-native)
chore(deps): add ^1.0.2 (devDependencies.rollup-plugin-consts)
chore(deps): add ^3.2.1 (devDependencies.rollup-plugin-cleanup)
chore(deps): add ^1.1.3 (devDependencies.rollup-plugin-dev)
chore(deps): add ^7.0.2 (devDependencies.rollup-plugin-terser)
chore(deps): add 2.5.0 (devDependencies.rollup-plugin-gzip)
chore(package): add https://somewhere/ (config.proxyTarget)
chore(package): (release.plugins)

.gitignore
---
- chore: add bundle.* ()

rollup.config.mjs
---
- chore(rollup): add missing rollup.config.mjs from template

