### PR TITLE
merge from konsum-frontend-svelte

### DIFF
--- a/.github/workflows/browser_ci.yml
+++ b/.github/workflows/browser_ci.yml
@@ -2,7 +2,7 @@ name: CI
 'on': push
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
@@ -11,6 +11,7 @@ jobs:
           - chrome
           - firefox
         node-version: 18.7.0
+        node: 18.7.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.4.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@konsumation/frontend-svelte",
-  "version": "1.32.0",
+  "version": "0.0.0-semantic-release",
   "publishConfig": {
     "access": "public"
   },
@@ -59,7 +59,7 @@
     "stylelint": "^14.9.1",
     "stylelint-config-standard": "^26.0.0",
     "svelte": "^3.49.0",
-    "testcafe": "^1.20.0",
+    "testcafe": "^1.20.1",
     "vite": "^3.0.4"
   },
   "optionalDependencies": {


### PR DESCRIPTION
package.json
---
- chore(package): add 0.0.0-semantic-release (version)
chore(deps): add ^1.20.1 remove ^1.20.0 (devDependencies.testcafe)

.github/workflows/browser_ci.yml
---
- chore: add ${{ matrix.os }} (jobs.test.runs-on)
chore(deps): add 18.7.0 (jobs.test.strategy.matrix.node)

