### PR TITLE
merge from konsum-frontend-svelte

### DIFF
--- a/.github/workflows/browser_ci.yml
+++ b/.github/workflows/browser_ci.yml
@@ -2,7 +2,7 @@ name: CI
 'on': push
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Svelte v3](https://img.shields.io/badge/svelte-v3-orange.svg)](https://svelte.dev)
 [![npm](https://img.shields.io/npm/v/@konsumation/frontend-svelte.svg)](https://www.npmjs.com/package/@konsumation/frontend-svelte)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![install size](https://packagephobia.now.sh/badge?p=@konsumation/frontend-svelte/@1.34.11)](https://packagephobia.now.sh/result?p=@konsumation/frontend-svelte@1.34.11)
 [![Open Bundle](https://bundlejs.com/badge-light.svg)](https://bundlejs.com/?q=@konsumation/frontend-svelte)
 [![downloads](http://img.shields.io/npm/dm/@konsumation/frontend-svelte.svg?style=flat-square)](https://npmjs.org/package/@konsumation/frontend-svelte)
 [![GitHub Issues](https://img.shields.io/github/issues/konsumation/konsum-frontend-svelte.svg?style=flat-square)](https://github.com/konsumation/konsum-frontend-svelte/issues)

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "npm-dep-graph": "^1.0.61",
     "streamsaver": "^2.0.6",
     "svelte-command": "^1.1.24",
-    "svelte-common": "^4.19.19",
+    "svelte-common": "^4.19.20",
     "svelte-entitlement": "^1.2.38",
-    "svelte-guard-history-router": "^5.5.9",
+    "svelte-guard-history-router": "^5.5.10",
     "svelte-log-view": "^4.2.14",
     "svelte-session-manager": "^2.0.11",
     "the-new-css-reset": "^1.7.2"
@@ -56,7 +56,7 @@
     "ava": "^5.1.0",
     "npm-pkgbuild": "^10.15.17",
     "semantic-release": "^19.0.5",
-    "stylelint": "^14.15.0",
+    "stylelint": "^14.16.0",
     "stylelint-config-standard": "^29.0.0",
     "svelte": "^3.53.1",
     "testcafe": "^2.1.0",
@@ -94,12 +94,6 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/npm",
-      [
-        "@semantic-release/exec",
-        {
-          "publishCmd": "npx npm-pkgbuild --available --continue --publist dist"
-        }
-      ],
       [
         "@semantic-release/exec",
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@konsumation/frontend-svelte",
-  "version": "1.34.11",
+  "version": "0.0.0-semantic-release",
   "publishConfig": {
     "access": "public"
   },
@@ -52,7 +52,7 @@
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/release-notes-generator": "^10.0.3",
-    "@sveltejs/vite-plugin-svelte": "^1.3.1",
+    "@sveltejs/vite-plugin-svelte": "^1.4.0",
     "ava": "^5.1.0",
     "npm-pkgbuild": "^10.15.17",
     "semantic-release": "^19.0.5",
@@ -98,6 +98,12 @@
         "@semantic-release/exec",
         {
           "publishCmd": "npx npm-pkgbuild --available --continue --publist dist"
+        }
+      ],
+      [
+        "@semantic-release/exec",
+        {
+          "publishCmd": "npx npm-pkgbuild --available --continue --publish dist"
         }
       ],
       [


### PR DESCRIPTION
package.json
---
- chore(package): add 0.0.0-semantic-release (version)
chore(deps): add ^1.4.0 remove ^1.3.1 (devDependencies.@sveltejs/vite-plugin-svelte)
chore(deps): add ^14.16.0 remove ^14.15.0 (devDependencies.stylelint)

README.md
---
- docs(README): update from template

.github/workflows/browser_ci.yml
---
- chore: add ${{ matrix.os }} (jobs.test.runs-on)

