### PR TITLE
merge from konsum-frontend-svelte

### DIFF
--- a/.github/workflows/browser_ci.yml
+++ b/.github/workflows/browser_ci.yml
@@ -2,7 +2,7 @@ name: CI
 'on': push
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@konsumation/frontend-svelte",
-  "version": "1.34.11",
+  "version": "0.0.0-semantic-release",
   "publishConfig": {
     "access": "public"
   },
@@ -61,7 +61,7 @@
     "stylelint-config-standard": "^29.0.0",
     "svelte": "^3.53.1",
     "testcafe": "^2.1.0",
-    "vite": "^3.2.4"
+    "vite": "^3.2.5"
   },
   "optionalDependencies": {
     "mf-hosting": "^1.7.9"


### PR DESCRIPTION
package.json
---
- chore(package): add 0.0.0-semantic-release (version)
chore(deps): add ^3.2.5 remove ^3.2.4 (devDependencies.vite)

.github/workflows/browser_ci.yml
---
- chore: add ${{ matrix.os }} (jobs.test.runs-on)

